### PR TITLE
feat: add computer-use graph

### DIFF
--- a/apps/open-swe/src/graphs/computer-use/__tests__/graph.test.ts
+++ b/apps/open-swe/src/graphs/computer-use/__tests__/graph.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "@jest/globals";
+import { graph } from "../index.js";
+import { GraphConfig } from "@open-swe/shared/open-swe/types";
+
+// Graph invocation requires Node runtime to support local mode.
+// This test ensures the graph executes end-to-end in local mode.
+describe("computer-use graph", () => {
+  it("runs command and returns output", async () => {
+    const config = { configurable: { "x-local-mode": "true" } } as GraphConfig;
+    const result = await graph.invoke(
+      {
+        command: "echo hi",
+        targetRepository: { owner: "foo", repo: "bar" },
+        branchName: "main",
+      },
+      config,
+    );
+    expect(result.commandResult).toContain("hi");
+  });
+});

--- a/apps/open-swe/src/graphs/computer-use/__tests__/run-command.test.ts
+++ b/apps/open-swe/src/graphs/computer-use/__tests__/run-command.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "@jest/globals";
+import { runCommand } from "../nodes/run-command.js";
+import type { ComputerUseGraphState } from "../state.js";
+import { GraphConfig } from "@open-swe/shared/open-swe/types";
+
+describe("runCommand", () => {
+  it("executes shell command in local mode", async () => {
+    const state = {
+      command: "echo hello",
+      sandboxSessionId: "",
+      targetRepository: { owner: "foo", repo: "bar" },
+      branchName: "main",
+    } as unknown as ComputerUseGraphState;
+
+    const config = { configurable: { "x-local-mode": "true" } } as GraphConfig;
+
+    const result = await runCommand(state, config);
+    expect(result.commandResult).toContain("hello");
+  });
+});

--- a/apps/open-swe/src/graphs/computer-use/index.ts
+++ b/apps/open-swe/src/graphs/computer-use/index.ts
@@ -1,0 +1,17 @@
+import { START, END, StateGraph } from "@langchain/langgraph";
+import { GraphConfiguration } from "@open-swe/shared/open-swe/types";
+import { initializeSandbox } from "../shared/initialize-sandbox.js";
+import { runCommand, cleanup } from "./nodes/index.js";
+import { ComputerUseGraphStateObj } from "./state.js";
+
+const workflow = new StateGraph(ComputerUseGraphStateObj, GraphConfiguration)
+  .addNode("initialize", initializeSandbox)
+  .addNode("run-command", runCommand)
+  .addNode("cleanup", cleanup)
+  .addEdge(START, "initialize")
+  .addEdge("initialize", "run-command")
+  .addEdge("run-command", "cleanup")
+  .addEdge("cleanup", END);
+
+export const graph = workflow.compile();
+graph.name = "Open SWE - Computer Use";

--- a/apps/open-swe/src/graphs/computer-use/nodes/cleanup.ts
+++ b/apps/open-swe/src/graphs/computer-use/nodes/cleanup.ts
@@ -1,0 +1,15 @@
+import { stopSandbox, deleteSandbox } from "../../../utils/sandbox.js";
+import { isLocalMode } from "@open-swe/shared/open-swe/local-mode";
+import type { GraphConfig } from "@open-swe/shared/open-swe/types";
+import type { ComputerUseGraphState } from "../state.js";
+
+export async function cleanup(
+  state: ComputerUseGraphState,
+  config: GraphConfig,
+): Promise<Partial<ComputerUseGraphState>> {
+  if (!isLocalMode(config) && state.sandboxSessionId) {
+    await stopSandbox(state.sandboxSessionId);
+    await deleteSandbox(state.sandboxSessionId);
+  }
+  return {};
+}

--- a/apps/open-swe/src/graphs/computer-use/nodes/index.ts
+++ b/apps/open-swe/src/graphs/computer-use/nodes/index.ts
@@ -1,0 +1,2 @@
+export * from "./run-command.js";
+export * from "./cleanup.js";

--- a/apps/open-swe/src/graphs/computer-use/nodes/run-command.ts
+++ b/apps/open-swe/src/graphs/computer-use/nodes/run-command.ts
@@ -1,0 +1,17 @@
+import { GraphConfig } from "@open-swe/shared/open-swe/types";
+import { executeCommand } from "../../../utils/shell-executor/index.js";
+import type { ComputerUseGraphState } from "../state.js";
+
+export async function runCommand(
+  state: ComputerUseGraphState,
+  config: GraphConfig,
+): Promise<Partial<ComputerUseGraphState>> {
+  const response = await executeCommand(config, {
+    command: state.command,
+    sandboxSessionId: state.sandboxSessionId,
+  });
+
+  return {
+    commandResult: response.result ?? "",
+  };
+}

--- a/apps/open-swe/src/graphs/computer-use/state.ts
+++ b/apps/open-swe/src/graphs/computer-use/state.ts
@@ -1,0 +1,9 @@
+import { GraphAnnotation } from "@open-swe/shared/open-swe/types";
+import { z } from "zod";
+
+export const ComputerUseGraphStateObj = GraphAnnotation.extend({
+  command: z.string(),
+  commandResult: z.string().optional(),
+});
+
+export type ComputerUseGraphState = z.infer<typeof ComputerUseGraphStateObj>;

--- a/langgraph.json
+++ b/langgraph.json
@@ -3,7 +3,8 @@
   "graphs": {
     "programmer": "./apps/open-swe/src/graphs/programmer/index.ts:graph",
     "planner": "./apps/open-swe/src/graphs/planner/index.ts:graph",
-    "manager": "./apps/open-swe/src/graphs/manager/index.ts:graph"
+    "manager": "./apps/open-swe/src/graphs/manager/index.ts:graph",
+    "computer-use": "./apps/open-swe/src/graphs/computer-use/index.ts:graph"
   },
   "env": "./apps/open-swe/.env",
   "dependencies": ["./apps/open-swe"],


### PR DESCRIPTION
## Summary
- add computer-use LangGraph with sandbox init, command execution, and cleanup nodes
- map new graph in langgraph.json
- test computer-use graph command execution

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689f4f6a67b8832a878852fc7ecf186d